### PR TITLE
[wip] Deal with CodeBuild concurrency limits

### DIFF
--- a/cloudformation/stork.template.js
+++ b/cloudformation/stork.template.js
@@ -169,18 +169,21 @@ const Resources = {
     }
   },
   TriggerLambdaErrorAlarm: {
-    Period: 60,
-    EvaluationPeriods: 1,
-    Statistic: 'Sum',
-    Threshold: 0,
-    ComparisonOperator: 'GreaterThanThreshold',
-    TreatMissingData: 'notBreaching',
-    Namespace: 'AWS/Lambda',
-    Dimensions: [
-      { Name: 'FunctionName', Value: cf.ref('TriggerLambda') }
-    ],
-    MetricName: 'Errors',
-    AlarmActions: [cf.ref('AlarmSNSTopic')]
+    Type: 'AWS::CloudWatch::Alarm',
+    Properties: {
+      Period: 60,
+      EvaluationPeriods: 1,
+      Statistic: 'Sum',
+      Threshold: 0,
+      ComparisonOperator: 'GreaterThanThreshold',
+      TreatMissingData: 'notBreaching',
+      Namespace: 'AWS/Lambda',
+      Dimensions: [
+        { Name: 'FunctionName', Value: cf.ref('TriggerLambda') }
+      ],
+      MetricName: 'Errors',
+      AlarmActions: [cf.ref('AlarmSNSTopic')]
+    }
   },
   StatusLambdaRole: {
     Type: 'AWS::IAM::Role',
@@ -251,18 +254,21 @@ const Resources = {
     }
   },
   StatusLambdaErrorAlarm: {
-    Period: 60,
-    EvaluationPeriods: 5,
-    Statistic: 'Sum',
-    Threshold: 0,
-    ComparisonOperator: 'GreaterThanThreshold',
-    TreatMissingData: 'notBreaching',
-    Namespace: 'AWS/Lambda',
-    Dimensions: [
-      { Name: 'FunctionName', Value: cf.ref('StatusLambda') }
-    ],
-    MetricName: 'Errors',
-    AlarmActions: [cf.ref('AlarmSNSTopic')]
+    Type: 'AWS::CloudWatch::Alarm',
+    Properties: {
+      Period: 60,
+      EvaluationPeriods: 5,
+      Statistic: 'Sum',
+      Threshold: 0,
+      ComparisonOperator: 'GreaterThanThreshold',
+      TreatMissingData: 'notBreaching',
+      Namespace: 'AWS/Lambda',
+      Dimensions: [
+        { Name: 'FunctionName', Value: cf.ref('StatusLambda') }
+      ],
+      MetricName: 'Errors',
+      AlarmActions: [cf.ref('AlarmSNSTopic')]
+    }
   },
   StatusFunctionPermission: {
     Type: 'AWS::Lambda::Permission',
@@ -341,18 +347,21 @@ const Resources = {
     }
   },
   ForwarderLambdaErrorAlarm: {
-    Period: 60,
-    EvaluationPeriods: 5,
-    Statistic: 'Sum',
-    Threshold: 0,
-    ComparisonOperator: 'GreaterThanThreshold',
-    TreatMissingData: 'notBreaching',
-    Namespace: 'AWS/Lambda',
-    Dimensions: [
-      { Name: 'FunctionName', Value: cf.ref('ForwarderLambda') }
-    ],
-    MetricName: 'Errors',
-    AlarmActions: [cf.ref('AlarmSNSTopic')]
+    Type: 'AWS::CloudWatch::Alarm',
+    Properties: {
+      Period: 60,
+      EvaluationPeriods: 5,
+      Statistic: 'Sum',
+      Threshold: 0,
+      ComparisonOperator: 'GreaterThanThreshold',
+      TreatMissingData: 'notBreaching',
+      Namespace: 'AWS/Lambda',
+      Dimensions: [
+        { Name: 'FunctionName', Value: cf.ref('ForwarderLambda') }
+      ],
+      MetricName: 'Errors',
+      AlarmActions: [cf.ref('AlarmSNSTopic')]
+    }
   },
   ForwarderLambdaPermission: {
     Type: 'AWS::Lambda::Permission',

--- a/cloudformation/stork.template.js
+++ b/cloudformation/stork.template.js
@@ -171,6 +171,7 @@ const Resources = {
   TriggerLambdaErrorAlarm: {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
+      AlarmName: cf.sub('${AWS::StackName}-trigger-function-errors'),
       Period: 60,
       EvaluationPeriods: 1,
       Statistic: 'Sum',
@@ -256,6 +257,7 @@ const Resources = {
   StatusLambdaErrorAlarm: {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
+      AlarmName: cf.sub('${AWS::StackName}-status-function-errors'),
       Period: 60,
       EvaluationPeriods: 5,
       Statistic: 'Sum',
@@ -349,6 +351,7 @@ const Resources = {
   ForwarderLambdaErrorAlarm: {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
+      AlarmName: cf.sub('${AWS::StackName}-forwarder-function-errors'),
       Period: 60,
       EvaluationPeriods: 5,
       Statistic: 'Sum',


### PR DESCRIPTION
- Add alarms when lambda functions error.
- If the trigger function fails, your build isn't going to run. Sends a github status update to indicate the failure.
- If the trigger function attempts to `StartBuild` and you're rate-limited, the github status update will tell you so, and instruct you to contact AWS to increase your limit.