### PR TITLE
do not error if sha cannot be found on github

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -512,19 +512,25 @@ stork.status = (event, context, callback) => {
       })
       .then(() => callback())
       .catch((err) => {
+        const shaToken = jwt.sign(
+          {
+            iss: appId,
+            iat: Math.floor(Date.now() / 1000),
+            exp: Math.floor(Date.now() / 1000) + (10 * 60)
+          },
+          privateKey,
+          { algorithm: 'RS256' }
+        );
         const shaUri = `https://api.github.com/repos/${owner}/${repo}/commits/${sha}`;
         const shaConfig = {
           json: true,
           headers: {
             'User-Agent': 'github.com/mapbox/stork',
             Accept: 'application/vnd.github.machine-man-preview+json',
-            Authorization: `Bearer ${token}`
+            Authorization: `Bearer ${shaToken}`
           }
         };
-        console.log('##############');
-        console.log(shaUri);
-        console.log(shaConfig);
-        console.log('##############');
+
         got.get(shaUri, shaConfig)
           .then((res) => {
             console.log(err);

--- a/lambda.js
+++ b/lambda.js
@@ -461,25 +461,21 @@ stork.status = (event, context, callback) => {
     ];
 
     let token;
-    let data;
-    let build;
-    let logs;
     let sha;
-    let source;
     let owner;
     let repo;
 
     Promise.all(requests)
       .then((results) => {
         token = results[0];
-        data = results[1];
+        const data = results[1];
 
-        build = data.builds[0];
+        const build = data.builds[0];
         if (!build) return;
 
-        logs = build.logs.deepLink;
+        const logs = build.logs.deepLink;
         sha = build.sourceVersion;
-        source = url.parse(build.source.location);
+        const source = url.parse(build.source.location);
         owner = source.pathname.split('/')[1];
         repo = source.pathname.split('/')[2].replace(/.git$/, '');
 

--- a/lambda.js
+++ b/lambda.js
@@ -460,19 +460,28 @@ stork.status = (event, context, callback) => {
         .catch((err) => Traceable.promise(err))
     ];
 
+    let token;
+    let data;
+    let build;
+    let logs;
+    let sha;
+    let source;
+    let owner;
+    let repo;
+
     Promise.all(requests)
       .then((results) => {
-        const token = results[0];
-        const data = results[1];
+        token = results[0];
+        data = results[1];
 
-        const build = data.builds[0];
+        build = data.builds[0];
         if (!build) return;
 
-        const logs = build.logs.deepLink;
-        const sha = build.sourceVersion;
-        const source = url.parse(build.source.location);
-        const owner = source.pathname.split('/')[1];
-        const repo = source.pathname.split('/')[2].replace(/.git$/, '');
+        logs = build.logs.deepLink;
+        sha = build.sourceVersion;
+        source = url.parse(build.source.location);
+        owner = source.pathname.split('/')[1];
+        repo = source.pathname.split('/')[2].replace(/.git$/, '');
 
         const uri = `https://api.github.com/repos/${owner}/${repo}/statuses/${sha}`;
         const status = {
@@ -503,8 +512,33 @@ stork.status = (event, context, callback) => {
       })
       .then(() => callback())
       .catch((err) => {
-        console.log(err);
-        callback(err);
+        const shaUri = `https://api.github.com/repos/${owner}/${repo}/commits/${sha}`;
+        const shaConfig = {
+          json: true,
+          headers: {
+            'User-Agent': 'github.com/mapbox/stork',
+            Accept: 'application/vnd.github.machine-man-preview+json',
+            Authorization: `Bearer ${token}`
+          }
+        };
+        console.log('##############');
+        console.log(shaUri);
+        console.log(shaConfig);
+        console.log('##############');
+        got.get(shaUri, shaConfig)
+          .then((res) => {
+            console.log(err);
+            callback(err);
+          })
+          .catch((shaErr) => {
+            if (shaErr.statusCode === 404 && shaErr.statusMessage === 'Not Found') {
+              console.log(err);
+              console.log('Sha does not exist, ignore stork error');
+              return callback();
+            }
+            console.log(err);
+            callback(err);
+          });
       });
   });
 };

--- a/lambda.js
+++ b/lambda.js
@@ -508,28 +508,17 @@ stork.status = (event, context, callback) => {
         console.log(`headers ${JSON.stringify(sanitized.headers)}`);
         console.log(`body ${sanitized.body}`);
 
-        console.log(uri);
-        console.log(config);
         return got.post(uri, config);
       })
       .then(() => callback())
       .catch((err) => {
-        const shaToken = jwt.sign(
-          {
-            iss: appId,
-            iat: Math.floor(Date.now() / 1000),
-            exp: Math.floor(Date.now() / 1000) + (10 * 60)
-          },
-          privateKey,
-          { algorithm: 'RS256' }
-        );
         const shaUri = `https://api.github.com/repos/${owner}/${repo}/commits/${sha}`;
         const shaConfig = {
           json: true,
           headers: {
             'User-Agent': 'github.com/mapbox/stork',
             Accept: 'application/vnd.github.machine-man-preview+json',
-            Authorization: `Bearer ${shaToken}`
+            Authorization: `token ${token}`
           }
         };
 
@@ -540,7 +529,6 @@ stork.status = (event, context, callback) => {
           })
           .catch((shaErr) => {
             if (shaErr.statusCode === 404 && shaErr.statusMessage === 'Not Found') {
-              console.log(err);
               console.log('Sha does not exist, ignore stork error');
               return callback();
             }

--- a/lambda.js
+++ b/lambda.js
@@ -508,6 +508,8 @@ stork.status = (event, context, callback) => {
         console.log(`headers ${JSON.stringify(sanitized.headers)}`);
         console.log(`body ${sanitized.body}`);
 
+        console.log(uri);
+        console.log(config);
         return got.post(uri, config);
       })
       .then(() => callback())

--- a/test/lambda.test.js
+++ b/test/lambda.test.js
@@ -1260,7 +1260,7 @@ test('[lambda] status: success', (assert) => {
   });
 });
 
-test('[lambda] status: github error, no sha', (assert) => {
+test('[lambda] status: github 422 error, get sha returns 404 not found', (assert) => {
   const environment = env(statusVars).mock();
 
   sinon.stub(lambda, 'decrypt').callsFake(fakeDecrypt);
@@ -1331,7 +1331,7 @@ test('[lambda] status: github error, no sha', (assert) => {
           headers: {
             'User-Agent': 'github.com/mapbox/stork',
             Accept: 'application/vnd.github.machine-man-preview+json',
-            Authorization: `Bearer ${auth}`
+            Authorization: 'token v1.1f699f1069f60xxx'
           }
         }
       ),
@@ -1347,7 +1347,94 @@ test('[lambda] status: github error, no sha', (assert) => {
   });
 });
 
-test('[lambda] status: github error, sha exists', (assert) => {
+test('[lambda] status: github 422 error, get sha returns non 404 error', (assert) => {
+  const environment = env(statusVars).mock();
+
+  sinon.stub(lambda, 'decrypt').callsFake(fakeDecrypt);
+
+  const getBuild = AWS.stub('CodeBuild', 'batchGetBuilds', function() {
+    this.request.promise.returns(Promise.resolve({
+      builds: [
+        {
+          logs: { deepLink: 'url for cloudwatch logs' },
+          sourceVersion: '12345shanotfound',
+          source: { location: 'https://github.com/mapbox/stork' }
+        }
+      ]
+    }));
+  });
+
+  sinon.stub(got, 'get')
+    .onCall(0).callsFake(() => Promise.resolve())
+    .onCall(1).callsFake(() => Promise.reject({
+      statusCode: 500,
+      statusMessage: 'Backend Error'
+    }));
+
+  sinon.stub(got, 'post')
+    .onCall(0).callsFake(() => Promise.resolve({
+      body: { token: 'v1.1f699f1069f60xxx' }
+    }))
+    .onCall(1).callsFake(() => Promise.reject({
+      statusCode: 422,
+      statusMessage: 'Unprocessable Entity'
+    }));
+
+  lambda.status(fakeStatusEvent, {}, (err) => {
+    const args = JSON.parse(JSON.stringify(got.post.args[0]));
+    const auth = args[1].headers.Authorization.replace('Bearer ', '');
+    const decoded = jwt.verify(auth, publicKey, { algorithms: ['RS256'] });
+
+    assert.equal(err.statusMessage, 'Unprocessable Entity', 'errors');
+
+    assert.ok(
+      got.post.calledWith(
+        'https://api.github.com/repos/mapbox/stork/statuses/12345shanotfound',
+        {
+          json: true,
+          headers: {
+            'Content-type': 'application/json',
+            'User-Agent': 'github.com/mapbox/stork',
+            Accept: 'application/vnd.github.machine-man-preview+json',
+            Authorization: 'token v1.1f699f1069f60xxx'
+          },
+          body: JSON.stringify({
+            context: 'stork',
+            description: 'Your build succeeded',
+            state: 'success',
+            target_url: 'url for cloudwatch logs'
+          })
+        }
+      ),
+      'sets PR status via github api request'
+    );
+
+    assert.equal(got.get.callCount, 2, '2 get requests to github api');
+    assert.ok(
+      got.get.calledWith(
+        'https://api.github.com/repos/mapbox/stork/commits/12345shanotfound',
+        {
+          json: true,
+          headers: {
+            'User-Agent': 'github.com/mapbox/stork',
+            Accept: 'application/vnd.github.machine-man-preview+json',
+            Authorization: 'token v1.1f699f1069f60xxx'
+          }
+        }
+      ),
+      'call to check if sha exists'
+    );
+
+    environment.restore();
+    got.get.restore();
+    got.post.restore();
+    lambda.decrypt.restore();
+    AWS.CodeBuild.restore();
+    assert.end();
+  });
+});
+
+test('[lambda] status: github 422 error, get sha returns 200', (assert) => {
   const environment = env(statusVars).mock();
 
   sinon.stub(lambda, 'decrypt').callsFake(fakeDecrypt);
@@ -1420,7 +1507,7 @@ test('[lambda] status: github error, sha exists', (assert) => {
           headers: {
             'User-Agent': 'github.com/mapbox/stork',
             Accept: 'application/vnd.github.machine-man-preview+json',
-            Authorization: `Bearer ${auth}`
+            Authorization: 'token v1.1f699f1069f60xxx'
           }
         }
       ),

--- a/test/lambda.test.js
+++ b/test/lambda.test.js
@@ -1366,7 +1366,7 @@ test('[lambda] status: github error, sha exists', (assert) => {
 
   sinon.stub(got, 'get')
     .onCall(0).callsFake(() => Promise.resolve())
-    .onCall(1).callsFake(() => Promise.reject({
+    .onCall(1).callsFake(() => Promise.resolve({
       statusCode: 200,
       statusMessage: 'OK',
       body: {
@@ -1375,7 +1375,10 @@ test('[lambda] status: github error, sha exists', (assert) => {
     }));
 
   sinon.stub(got, 'post')
-    .onCall(0).callsFake(() => Promise.reject({
+    .onCall(0).callsFake(() => Promise.resolve({
+      body: { token: 'v1.1f699f1069f60xxx' }
+    }))
+    .onCall(1).callsFake(() => Promise.reject({
       statusCode: 422,
       statusMessage: 'Unprocessable Entity'
     }));
@@ -1385,7 +1388,7 @@ test('[lambda] status: github error, sha exists', (assert) => {
     const auth = args[1].headers.Authorization.replace('Bearer ', '');
     const decoded = jwt.verify(auth, publicKey, { algorithms: ['RS256'] });
 
-    assert.equal(err.message, 'Response code 422 (Unprocessable Entity)', 'errors');
+    assert.equal(err.statusMessage, 'Unprocessable Entity', 'errors');
     assert.ok(
       got.post.calledWith(
         'https://api.github.com/repos/mapbox/stork/statuses/12345shaexists',

--- a/test/lambda.test.js
+++ b/test/lambda.test.js
@@ -1291,11 +1291,11 @@ test('[lambda] status: github error, no sha', (assert) => {
     }));
 
   lambda.status(fakeStatusEvent, {}, (err) => {
-    assert.ifError(err, 'does not error on missing GitSha');
+    const args = JSON.parse(JSON.stringify(got.post.args[0]));
+    const auth = args[1].headers.Authorization.replace('Bearer ', '');
+    const decoded = jwt.verify(auth, publicKey, { algorithms: ['RS256'] });
 
-    assert.ok(
-      got.get.onCall(1).calledWith()
-    ); 
+    assert.ifError(err, 'does not error on missing GitSha');
 
     assert.ok(
       got.post.calledWith(
@@ -1321,7 +1321,7 @@ test('[lambda] status: github error, no sha', (assert) => {
 
     assert.equal(got.get.callCount, 2, '2 get requests to github api');
     assert.ok(
-      got.get.onCall(1).calledWith(
+      got.get.calledWith(
         'https://api.github.com/repos/mapbox/stork/commits/529e7f60b159b18aabd7c699660b4b07603889c3',
         {
           json: true,


### PR DESCRIPTION
https://github.com/mapbox/stork/issues/27

@vsmart and I are working on the issue above where the function errors out when a gitsha is not found.

We are working on seeing if the `gitsha` exists with a call to the github api, and if it does not exist we do not have to return an error and can just exit the function. If the `gitsha` does exist, then we know it is an error we would want to look into.