### PR TITLE
install git for github-based dependencies #33

### DIFF
--- a/Dockerfiles/nodejs4.3
+++ b/Dockerfiles/nodejs4.3
@@ -1,6 +1,6 @@
 FROM amazonlinux
 
-RUN yum install -y wget zip
+RUN yum install -y wget zip git
 RUN curl -sL https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x64.tar.gz | tar zxC /usr/local --strip-components=1
 RUN rm -rf /usr/local/lib/node_modules/npm && \
   mkdir /usr/local/lib/node_modules/npm && \

--- a/Dockerfiles/nodejs6.x
+++ b/Dockerfiles/nodejs6.x
@@ -1,6 +1,6 @@
 FROM amazonlinux
 
-RUN yum install -y wget zip
+RUN yum install -y wget zip git
 RUN curl -sL https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x64.tar.gz | tar zxC /usr/local --strip-components=1
 RUN rm -rf /usr/local/lib/node_modules/npm && \
   mkdir /usr/local/lib/node_modules/npm && \


### PR DESCRIPTION
Fix for #33 : adding git in the image so that npm can install node dependencies given as git urls: https://docs.npmjs.com/files/package.json#git-urls-as-dependencies

It's not a big change, but I'm not sure how I should be testing this?

cc @rclark 