### PR TITLE
Specify NPM_ACCESS_TOKEN at build time

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -119,10 +119,7 @@ const createProject = (options) => {
     environment: {
       type: 'LINUX_CONTAINER',
       image: options.imageUri,
-      computeType: `BUILD_GENERAL1_${options.size.toUpperCase()}`,
-      environmentVariables: [
-        { name: 'NPM_ACCESS_TOKEN', value: options.npmToken }
-      ]
+      computeType: `BUILD_GENERAL1_${options.size.toUpperCase()}`
     }
   };
 
@@ -203,7 +200,13 @@ const runBuild = (options) => {
       location: options.bucket,
       path: `${options.prefix}/${options.repo}`,
       name: `${options.sha}.zip`
-    }
+    },
+    environmentVariablesOverride: [
+      {
+        name: 'NPM_ACCESS_TOKEN',
+        value: options.npmToken
+      }
+    ]
   };
 
   if (options.buildspec) params.buildspecOverride = options.buildspec;

--- a/test/lambda.test.js
+++ b/test/lambda.test.js
@@ -319,10 +319,7 @@ test('[lambda] trigger: new project, no overrides', (assert) => {
         environment: {
           type: 'LINUX_CONTAINER',
           image: '123456789012.dkr.ecr.us-east-1.amazonaws.com/stork:nodejs6.x',
-          computeType: 'BUILD_GENERAL1_SMALL',
-          environmentVariables: [
-            { name: 'NPM_ACCESS_TOKEN', value: 'secure:d;alfsksadafwe' }
-          ]
+          computeType: 'BUILD_GENERAL1_SMALL'
         }
       }),
       'created a new project with the appropriate properties'
@@ -369,6 +366,12 @@ test('[lambda] trigger: new project, no overrides', (assert) => {
           path: 'bundles/stork',
           name: 'abcdefg.zip'
         },
+        environmentVariablesOverride: [
+          {
+            name: 'NPM_ACCESS_TOKEN',
+            value: triggerVars.NPM_ACCESS_TOKEN
+          }
+        ],
         buildspecOverride: nodejs6Buildspec
       }),
       'runs the expected build'
@@ -458,6 +461,12 @@ test('[lambda] trigger: existing project, no overrides', (assert) => {
           path: 'bundles/stork',
           name: 'abcdefg.zip'
         },
+        environmentVariablesOverride: [
+          {
+            name: 'NPM_ACCESS_TOKEN',
+            value: triggerVars.NPM_ACCESS_TOKEN
+          }
+        ],
         buildspecOverride: nodejs6Buildspec
       }),
       'runs the expected build'
@@ -560,10 +569,7 @@ test('[lambda] trigger: new project, image override [python2.7]', (assert) => {
         environment: {
           type: 'LINUX_CONTAINER',
           image: '123456789012.dkr.ecr.us-east-1.amazonaws.com/stork:python2.7',
-          computeType: 'BUILD_GENERAL1_SMALL',
-          environmentVariables: [
-            { name: 'NPM_ACCESS_TOKEN', value: 'secure:d;alfsksadafwe' }
-          ]
+          computeType: 'BUILD_GENERAL1_SMALL'
         }
       }),
       'created a new project with the appropriate properties'
@@ -580,6 +586,12 @@ test('[lambda] trigger: new project, image override [python2.7]', (assert) => {
           path: 'bundles/stork',
           name: 'abcdefg.zip'
         },
+        environmentVariablesOverride: [
+          {
+            name: 'NPM_ACCESS_TOKEN',
+            value: triggerVars.NPM_ACCESS_TOKEN
+          }
+        ],
         buildspecOverride: pythonBuildspec
       }),
       'runs the expected build'
@@ -682,10 +694,7 @@ test('[lambda] trigger: new project, image override [nodejs4.3]', (assert) => {
         environment: {
           type: 'LINUX_CONTAINER',
           image: '123456789012.dkr.ecr.us-east-1.amazonaws.com/stork:nodejs4.3',
-          computeType: 'BUILD_GENERAL1_SMALL',
-          environmentVariables: [
-            { name: 'NPM_ACCESS_TOKEN', value: 'secure:d;alfsksadafwe' }
-          ]
+          computeType: 'BUILD_GENERAL1_SMALL'
         }
       }),
       'created a new project with the appropriate properties'
@@ -702,6 +711,12 @@ test('[lambda] trigger: new project, image override [nodejs4.3]', (assert) => {
           path: 'bundles/stork',
           name: 'abcdefg.zip'
         },
+        environmentVariablesOverride: [
+          {
+            name: 'NPM_ACCESS_TOKEN',
+            value: triggerVars.NPM_ACCESS_TOKEN
+          }
+        ],
         buildspecOverride: nodejs4Buildspec
       }),
       'runs the expected build'
@@ -804,10 +819,7 @@ test('[lambda] trigger: new project, image override [nodejs8.10]', (assert) => {
         environment: {
           type: 'LINUX_CONTAINER',
           image: '123456789012.dkr.ecr.us-east-1.amazonaws.com/stork:nodejs8.10',
-          computeType: 'BUILD_GENERAL1_SMALL',
-          environmentVariables: [
-            { name: 'NPM_ACCESS_TOKEN', value: 'secure:d;alfsksadafwe' }
-          ]
+          computeType: 'BUILD_GENERAL1_SMALL'
         }
       }),
       'created a new project with the appropriate properties'
@@ -824,6 +836,12 @@ test('[lambda] trigger: new project, image override [nodejs8.10]', (assert) => {
           path: 'bundles/stork',
           name: 'abcdefg.zip'
         },
+        environmentVariablesOverride: [
+          {
+            name: 'NPM_ACCESS_TOKEN',
+            value: triggerVars.NPM_ACCESS_TOKEN
+          }
+        ],
         buildspecOverride: nodejs8Buildspec
       }),
       'runs the expected build'
@@ -934,10 +952,7 @@ test('[lambda] trigger: new project, image, buildspec, size override', (assert) 
         environment: {
           type: 'LINUX_CONTAINER',
           image: '123456789012.dkr.ecr.us-east-1.amazonaws.com/stork:python2.7',
-          computeType: 'BUILD_GENERAL1_LARGE',
-          environmentVariables: [
-            { name: 'NPM_ACCESS_TOKEN', value: 'secure:d;alfsksadafwe' }
-          ]
+          computeType: 'BUILD_GENERAL1_LARGE'
         }
       }),
       'created a new project with the appropriate properties'
@@ -953,7 +968,13 @@ test('[lambda] trigger: new project, image, buildspec, size override', (assert) 
           location: 'mapbox-us-east-1',
           path: 'bundles/stork',
           name: 'abcdefg.zip'
-        }
+        },
+        environmentVariablesOverride: [
+          {
+            name: 'NPM_ACCESS_TOKEN',
+            value: triggerVars.NPM_ACCESS_TOKEN
+          }
+        ]
       }),
       'runs the expected build, inheriting buildspec.yml from the repo'
     );
@@ -1047,6 +1068,12 @@ test('[lambda] trigger: existing project, same overrides', (assert) => {
           path: 'bundles/stork',
           name: 'abcdefg.zip'
         },
+        environmentVariablesOverride: [
+          {
+            name: 'NPM_ACCESS_TOKEN',
+            value: triggerVars.NPM_ACCESS_TOKEN
+          }
+        ],
         buildspecOverride: pythonBuildspec
       }),
       'runs the expected build'


### PR DESCRIPTION
Stork specifies an `NPM_ACCESS_TOKEN` for each CodeBuild project when the project is first created. This means if the token ever changes, those projects will still be using the old token and will no longer be able to build.

This PR will pass through the `NPM_ACCESS_TOKEN` at build time rather than specifying it at project creation time. This allows all of Stork's CodeBuild projects to use the same NPM token as Stork, and receive updates whenever Stork does.

A future enhancement might be to store and rotate these values from the AWS Secret Manager, but this fix should un-break what I broke for now