### PR TITLE
Logging to debug edge case on Github 422

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -531,6 +531,9 @@ stork.status = (event, context, callback) => {
             if (shaErr.statusCode === 404 && shaErr.statusMessage === 'Not Found') {
               console.log('Sha does not exist, ignore stork error');
               return callback();
+            } else {
+              console.log('Attempted to fetch missing commit ' + sha + ', got this error:');
+              console.log(shaErr);
             }
             console.log(err);
             callback(err);


### PR DESCRIPTION
Ref https://github.com/mapbox/stork/issues/27#issuecomment-401168699
Despite checking for not-found gitshas on line https://github.com/mapbox/stork/blob/master/lambda.js#L531, we are seeing errors raised for commits that are not found, which are not caught by this clause. 

Possible theory:
- something about the "not found" response changed and doesnt match our condition anymore

This adds another log to show the response of the "does-this-gitsha-exist" call, if the call does not return 404/not found. 